### PR TITLE
How cooperative model might work

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -400,6 +400,7 @@ import * as syntheticNounsClaimerOwner from './synthetic-nouns-with-claimer';
 import * as depositInSablierStream from './deposit-in-sablier-stream';
 import * as echelonWalletPrimeAndCachedKey from './echelon-wallet-prime-and-cached-key';
 import * as nation3VotesWIthDelegations from './nation3-votes-with-delegations';
+import * as nation3CoopPassportWithDelegations from './nation3-passport-coop-with-delegations'
 import * as aavegotchiAgip37WapGhst from './aavegotchi-agip-37-wap-ghst';
 import * as aavegotchiAgip37GltrStakedLp from './aavegotchi-agip-37-gltr-staked-lp';
 import * as posichainStaking from './posichain-staking';
@@ -857,6 +858,7 @@ const strategies = {
   'deposit-in-sablier-stream': depositInSablierStream,
   'echelon-wallet-prime-and-cached-key': echelonWalletPrimeAndCachedKey,
   'nation3-votes-with-delegations': nation3VotesWIthDelegations,
+  'nation3-passport-coop-with-delegations':nation3CoopPassportWithDelegations,
   'aavegotchi-agip-37-wap-ghst': aavegotchiAgip37WapGhst,
   'aavegotchi-agip-37-gltr-staked-lp': aavegotchiAgip37GltrStakedLp,
   'erc20-tokens-per-uni': erc20TokensPerUni,

--- a/src/strategies/nation3-passport-coop-with-delegations/README.md
+++ b/src/strategies/nation3-passport-coop-with-delegations/README.md
@@ -1,0 +1,13 @@
+# Nation3 voting power strategy
+
+Calculates voting power using a cooperative model (one person one vote) based on a user's ownership of nation3 passport (_erc721 NFT_). It also takes into account whether the NFT owner delegated his voting power to another account (using the `setSigner` function)
+
+## Requires 2 input parameters:
+
+**erc20**
+
+The address of veNation tokens contract
+
+**erc721**
+
+The address of nation3 passport tokens contract

--- a/src/strategies/nation3-passport-coop-with-delegations/README.md
+++ b/src/strategies/nation3-passport-coop-with-delegations/README.md
@@ -2,11 +2,7 @@
 
 Calculates voting power using a cooperative model (one person one vote) based on a user's ownership of nation3 passport (_erc721 NFT_). It also takes into account whether the NFT owner delegated his voting power to another account (using the `setSigner` function)
 
-## Requires 2 input parameters:
-
-**erc20**
-
-The address of veNation tokens contract
+## Requires 1 input parameters:
 
 **erc721**
 

--- a/src/strategies/nation3-passport-coop-with-delegations/examples.json
+++ b/src/strategies/nation3-passport-coop-with-delegations/examples.json
@@ -4,8 +4,7 @@
     "strategy": {
       "name": "nation3-passport-coop-with-delegations",
       "params": {
-        "erc721": "0x3337dac9f251d4e403d6030e18e3cfb6a2cb1333",
-        "erc20": "0xf7def1d2fbda6b74bee7452fdf7894da9201065d"
+        "erc721": "0x3337dac9f251d4e403d6030e18e3cfb6a2cb1333"
       }
     },
     "network": "1",

--- a/src/strategies/nation3-passport-coop-with-delegations/examples.json
+++ b/src/strategies/nation3-passport-coop-with-delegations/examples.json
@@ -1,8 +1,8 @@
 [
   {
-    "name": "Voting Power with ERC20 Balances (only for ERC721 Holders) ",
+    "name": "One Person One Vote (only for ERC721 Holders or Delegates) ",
     "strategy": {
-      "name": "nation3-votes-with-delegations",
+      "name": "nation3-passport-coop-with-delegations",
       "params": {
         "erc721": "0x3337dac9f251d4e403d6030e18e3cfb6a2cb1333",
         "erc20": "0xf7def1d2fbda6b74bee7452fdf7894da9201065d"
@@ -17,6 +17,6 @@
       "0xfafda3727fe0406e50230bf6092be5ded68cd9e9",
       "0x79438224Bc21b0E6B45ECF9F8caADfBdB874DedD"
     ],
-    "snapshot": 16399660
+    "snapshot": 17683972
   }
 ]

--- a/src/strategies/nation3-passport-coop-with-delegations/index.ts
+++ b/src/strategies/nation3-passport-coop-with-delegations/index.ts
@@ -4,16 +4,6 @@ import { Multicaller } from '../../utils';
 export const author = 'nation3';
 export const version = '0.2.0';
 
-//if we use balances we need this
-//const DECIMALS = 18;
-
-//if we use balances we need this
-// const balanceAbi = [
-//   'function balanceOf(address account) external view returns (uint256)'
-// ];
-
-const ownerAbi = ['function ownerOf(uint256 id) public view returns (address)'];
-
 const signerAbi = [
   'function signerOf(uint256 id) external view  returns (address)'
 ];
@@ -30,12 +20,6 @@ export async function strategy(
 ): Promise<Record<string, number>> {
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
-  //if we use balances we need this
-  //const formattedAddressesThatVoted = addresses.map((addr) => getAddress(addr));
-
-  const erc721OwnerCaller = new Multicaller(network, provider, ownerAbi, {
-    blockTag
-  });
   const erc721SignerCaller = new Multicaller(network, provider, signerAbi, {
     blockTag
   });
@@ -46,11 +30,6 @@ export async function strategy(
     { blockTag }
   );
 
-  //if we use balances we need this
-  // const erc20BalanceCaller = new Multicaller(network, provider, balanceAbi, {
-  //   blockTag
-  // });
-
   erc721LastTokenIdCaller.call('lastTokenId', options.erc721, 'getNextId');
 
   const lastIndex = await erc721LastTokenIdCaller.execute();
@@ -58,24 +37,19 @@ export async function strategy(
 
   for (let i = 0; i < lastTokenId; i++) {
     erc721SignerCaller.call(i, options.erc721, 'signerOf', [i]);
-    erc721OwnerCaller.call(i, options.erc721, 'ownerOf', [i]);
   }
 
-  const [erc721Signers/*, erc721Owners*/]: [
-    Record<string, string>,
-    //Record<string, string>
+  const [erc721Signers]: [
+    Record<string, string>
   ] = await Promise.all([
-    erc721SignerCaller.execute(),
-    //erc721OwnerCaller.execute()
+    erc721SignerCaller.execute()
   ]);
 
-  //if we use balances we need this
-  //const erc721OwnersArr = Object.entries(erc721Owners);
   const erc721SignersArr = Object.entries(erc721Signers);
 
-  //here is where we would/could filter out passports based on token balances
-  //using the ownerAddress. The signer defaults to the owner if has not been set.
-  const eligibleAddresses = erc721SignersArr.map(([id, address]) => address);
+  const eligibleAddresses = erc721SignersArr
+    .map(([_, address]) => address)
+    .filter((address) => addresses.includes(address));
 
   return Object.fromEntries(
     eligibleAddresses.map((value, i) => [

--- a/src/strategies/nation3-passport-coop-with-delegations/index.ts
+++ b/src/strategies/nation3-passport-coop-with-delegations/index.ts
@@ -1,0 +1,86 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { Multicaller } from '../../utils';
+
+export const author = 'nation3';
+export const version = '0.2.0';
+
+//if we use balances we need this
+//const DECIMALS = 18;
+
+//if we use balances we need this
+// const balanceAbi = [
+//   'function balanceOf(address account) external view returns (uint256)'
+// ];
+
+const ownerAbi = ['function ownerOf(uint256 id) public view returns (address)'];
+
+const signerAbi = [
+  'function signerOf(uint256 id) external view  returns (address)'
+];
+
+const lastTokenIdAbi = ['function getNextId() external view returns (uint256)'];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses: string[],
+  options,
+  snapshot
+): Promise<Record<string, number>> {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  //if we use balances we need this
+  //const formattedAddressesThatVoted = addresses.map((addr) => getAddress(addr));
+
+  const erc721OwnerCaller = new Multicaller(network, provider, ownerAbi, {
+    blockTag
+  });
+  const erc721SignerCaller = new Multicaller(network, provider, signerAbi, {
+    blockTag
+  });
+  const erc721LastTokenIdCaller = new Multicaller(
+    network,
+    provider,
+    lastTokenIdAbi,
+    { blockTag }
+  );
+
+  //if we use balances we need this
+  // const erc20BalanceCaller = new Multicaller(network, provider, balanceAbi, {
+  //   blockTag
+  // });
+
+  erc721LastTokenIdCaller.call('lastTokenId', options.erc721, 'getNextId');
+
+  const lastIndex = await erc721LastTokenIdCaller.execute();
+  const lastTokenId = BigNumber.from(lastIndex.lastTokenId).toNumber();
+
+  for (let i = 0; i < lastTokenId; i++) {
+    erc721SignerCaller.call(i, options.erc721, 'signerOf', [i]);
+    erc721OwnerCaller.call(i, options.erc721, 'ownerOf', [i]);
+  }
+
+  const [erc721Signers/*, erc721Owners*/]: [
+    Record<string, string>,
+    //Record<string, string>
+  ] = await Promise.all([
+    erc721SignerCaller.execute(),
+    //erc721OwnerCaller.execute()
+  ]);
+
+  //if we use balances we need this
+  //const erc721OwnersArr = Object.entries(erc721Owners);
+  const erc721SignersArr = Object.entries(erc721Signers);
+
+  //here is where we would/could filter out passports based on token balances
+  //using the ownerAddress. The signer defaults to the owner if has not been set.
+  const eligibleAddresses = erc721SignersArr.map(([id, address]) => address);
+
+  return Object.fromEntries(
+    eligibleAddresses.map((value, i) => [
+      value,
+      1
+    ])
+  );
+}

--- a/src/strategies/nation3-passport-coop-with-delegations/schema.json
+++ b/src/strategies/nation3-passport-coop-with-delegations/schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/Strategy",
+  "definitions": {
+    "Strategy": {
+      "title": "Strategy",
+      "type": "object",
+      "properties": {
+        "erc20": {
+          "type": "string",
+          "title": "veNation",
+          "examples": ["e.g. 0xf7def1d2fbda6b74bee7452fdf7894da9201065d"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        },
+        "erc721": {
+          "type": "string",
+          "title": "nation3 passport",
+          "examples": ["e.g. 0x3337dac9f251d4e403d6030e18e3cfb6a2cb1333"],
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "minLength": 42,
+          "maxLength": 42
+        }
+      },
+      "required": ["erc20", "erc721"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/strategies/nation3-passport-coop-with-delegations/schema.json
+++ b/src/strategies/nation3-passport-coop-with-delegations/schema.json
@@ -6,14 +6,6 @@
       "title": "Strategy",
       "type": "object",
       "properties": {
-        "erc20": {
-          "type": "string",
-          "title": "veNation",
-          "examples": ["e.g. 0xf7def1d2fbda6b74bee7452fdf7894da9201065d"],
-          "pattern": "^0x[a-fA-F0-9]{40}$",
-          "minLength": 42,
-          "maxLength": 42
-        },
         "erc721": {
           "type": "string",
           "title": "nation3 passport",
@@ -23,7 +15,7 @@
           "maxLength": 42
         }
       },
-      "required": ["erc20", "erc721"],
+      "required": ["erc721"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
Adds a new voting strategy that currently just looks for the signer addresses of all passports and assigns them a voting weight of 1.

Commented out code left in as it would be required if we wanted to do a balance check for owner balances > 2 veNation, but would propose to remove all this and handle that elsewhere.