### PR TITLE
🐛 Fix breaking issue with revoked passports

### DIFF
--- a/src/strategies/nation3-passport-coop-with-delegations/index.ts
+++ b/src/strategies/nation3-passport-coop-with-delegations/index.ts
@@ -1,6 +1,8 @@
-import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { getAddress } from '@ethersproject/address';
+import { BigNumberish } from '@ethersproject/bignumber';
 import { Multicaller } from '../../utils';
 import { formatUnits } from '@ethersproject/units';
+import { subgraphRequest } from '../../utils';
 
 export const author = 'nation3';
 export const version = '0.3.0';
@@ -10,14 +12,6 @@ const DECIMALS = 18;
 const balanceAbi = [
   'function balanceOf(address account) external view returns (uint256)'
 ];
-
-const ownerAbi = ['function ownerOf(uint256 id) public view returns (address)'];
-
-const signerAbi = [
-  'function signerOf(uint256 id) external view  returns (address)'
-];
-
-const lastTokenIdAbi = ['function getNextId() external view returns (uint256)'];
 
 export async function strategy(
   space,
@@ -29,67 +23,63 @@ export async function strategy(
 ): Promise<Record<string, number>> {
   const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
 
-  const erc721SignerCaller = new Multicaller(network, provider, signerAbi, {
-    blockTag
-  });
-  const erc721OwnerCaller = new Multicaller(network, provider, ownerAbi, {
-    blockTag
-  });
   const erc20BalanceCaller = new Multicaller(network, provider, balanceAbi, {
     blockTag
   });
-  const erc721LastTokenIdCaller = new Multicaller(
-    network,
-    provider,
-    lastTokenIdAbi,
-    { blockTag }
-  );
 
-  erc721LastTokenIdCaller.call('lastTokenId', options.erc721, 'getNextId');
+  const erc721BalanceCaller = new Multicaller(network, provider, balanceAbi, {
+    blockTag
+  });
 
-  const lastIndex = await erc721LastTokenIdCaller.execute();
-  const lastTokenId = BigNumber.from(lastIndex.lastTokenId).toNumber();
+  const passportIssuanceSubgrgraph = "https://api.thegraph.com/subgraphs/name/nation3/passportissuance"
 
-  for (let i = 1; i < lastTokenId; i++) {
-    erc721SignerCaller.call(i, options.erc721, 'signerOf', [i]);
-    erc721OwnerCaller.call(i, options.erc721, 'ownerOf', [i]);
-  }
-
-  const [erc721Signers, erc721Owners]: [
-    Record<string, string>,
-    Record<string, string>
-  ] = await Promise.all([
-    erc721SignerCaller.execute(),
-    erc721OwnerCaller.execute()
-  ]);
-
-  const erc721SignersArr = Object.entries(erc721Signers);
-  const erc721OwnersArr = Object.entries(erc721Owners);
-
-  const eligibleAddresses = erc721SignersArr.filter(([, address]) =>
-    addresses.includes(address)
-  );
-
-  //create a combined tuple
-  const eligibleSignerOwner: [string, string, string][] = eligibleAddresses.map(
-    ([id, signerAddress]) => {
-      const owner = erc721OwnersArr.find(([ownerId]) => id === ownerId);
-      return [id, signerAddress, owner ? owner[1] : '0x0'];
+  const revokedUsersResponse = await subgraphRequest(passportIssuanceSubgrgraph, {
+    revokes: {
+      __args: {
+        where: { _to_in: addresses }
+      },
+      id: true,
+      _to: true
     }
-  );
+  });
 
-  eligibleSignerOwner.forEach(([, , owner]) =>
+  const revokedUsers: string[] = revokedUsersResponse.revokes.map(revokeObject => {
+    return getAddress(revokeObject._to);
+  });
+
+
+  const eligibleAddresses: string[] = addresses.filter((address) => {
+    return !revokedUsers.includes(getAddress(address));
+  });
+
+
+  eligibleAddresses.forEach((owner) =>
     erc20BalanceCaller.call(owner, options.erc20, 'balanceOf', [owner])
   );
 
   const erc20Balances: Record<string, BigNumberish> =
     await erc20BalanceCaller.execute();
 
-  //now we have balances, need to check for > 1.5 on all IDs that have voted
-  const withPower = eligibleSignerOwner.filter(([, , owner]) => {
-    const balance = erc20Balances[owner] || 0;
-    return parseFloat(formatUnits(balance, DECIMALS)) > 1.5;
+
+  eligibleAddresses.forEach((owner) =>
+    erc721BalanceCaller.call(owner, options.erc721, 'balanceOf', [owner])
+  );
+
+  const erc721Balances: Record<string, BigNumberish> =
+    await erc721BalanceCaller.execute();
+
+
+  const eligibleAddressesWithPassports = eligibleAddresses.filter((owner) => {
+    const passportBalance = erc721Balances[owner] || 0;
+    return parseFloat(formatUnits(passportBalance, DECIMALS)) > 0;
   });
 
-  return Object.fromEntries(withPower.map(([, signer]) => [signer, 1])) || [];
+  //now we have balances, need to check for > 1.5 on all IDs that have voted
+  const withPower = eligibleAddressesWithPassports.filter((owner) => {
+    const veNationBalance = erc20Balances[owner] || 0;
+
+    return parseFloat(formatUnits(veNationBalance, DECIMALS)) > 1.5;
+  });
+
+  return Object.fromEntries(withPower.map(([, signer]) => [signer, 1]));
 }


### PR DESCRIPTION
Fixes #5  .

Changes proposed in this pull request:
- 🐛 Fix issue with revoked passports, use `PassportIssuer` subgraph to filter out passports which are revoked
  - utilises [subgraph](https://thegraph.com/hosted-service/subgraph/nation3/passportissuance) to get list of revoked ids

All changes pass the following tests:

```console
yarn test --strategy=nation3-passport-coop-with-delegations
```
